### PR TITLE
Fixed Issue #12

### DIFF
--- a/lib/jekyll-minimagick.rb
+++ b/lib/jekyll-minimagick.rb
@@ -40,7 +40,7 @@ module Jekyll
 
         return false if File.exist? dest_path and !modified?
 
-        @@mtimes[path] = mtime
+        self.class.mtimes[path] = mtime
 
         FileUtils.mkdir_p(File.dirname(dest_path))
         image = ::MiniMagick::Image.open(path)


### PR DESCRIPTION
Fixed error "keep getting uninitialized @@mtimes on jekyll versions above 3.1.6" as mentioned [here](https://github.com/zroger/jekyll-minimagick/issues/12).
